### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/gbbinfojpn/database/views/views.py
+++ b/gbbinfojpn/database/views/views.py
@@ -120,7 +120,9 @@ def health_check(request):
             }
         )
     except Exception as e:
-        return JsonResponse({"error": str(e)}, status=500)
+        import logging
+        logging.error("An error occurred during health check:", exc_info=True)
+        return JsonResponse({"error": "An internal error has occurred."}, status=500)
 
 
 def test_data_list(request):


### PR DESCRIPTION
Potential fix for [https://github.com/shumizu418128/gbbinfo3.0/security/code-scanning/6](https://github.com/shumizu418128/gbbinfo3.0/security/code-scanning/6)

To fix the issue, the error message should be replaced with a generic message that does not expose sensitive information. The stack trace or detailed exception message should be logged on the server for debugging purposes, but the user-facing response should only indicate that an internal error occurred.

**Steps to implement the fix:**
1. Replace the `str(e)` in the JSON response with a generic error message, such as `"An internal error has occurred."`.
2. Log the exception details (including the stack trace) on the server using Python's `logging` module.
3. Ensure that the logging configuration is set up to capture and store error logs securely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
