### PR TITLE
Potential fix for code scanning alert no. 24: URL redirection from remote source

### DIFF
--- a/app/views/language.py
+++ b/app/views/language.py
@@ -21,12 +21,11 @@ def change_language(BABEL_SUPPORTED_LOCALES: list[str]):
 
     # 直前のページ（リファラー）を取得する
     current_url = request.headers.get("Referer", "/")
+    # Remove backslashes to prevent browser quirks
+    current_url = current_url.replace("\\", "")
     parsed_url = urlparse(current_url)
-
-    # 内部URLかつパスが/で始まる場合のみ許可
-    if parsed_url.netloc and parsed_url.netloc != request.host:
-        current_url = "/"
-    elif not parsed_url.path.startswith("/"):
+    # Only allow relative URLs (no scheme, no netloc) and path must start with /
+    if parsed_url.scheme or parsed_url.netloc or not parsed_url.path.startswith("/"):
         current_url = "/"
 
     # クッキーにも保存し、referrerにリダイレクト


### PR DESCRIPTION
Potential fix for [https://github.com/shumizu418128/gbbinfo3.0/security/code-scanning/24](https://github.com/shumizu418128/gbbinfo3.0/security/code-scanning/24)

To fix the problem, we should ensure that the redirect target is always a safe, internal URL. The best way to do this is to use a robust validation method that accounts for browser quirks and edge cases. The recommended approach is to remove backslashes from the URL, and only allow redirects to relative URLs that do not specify a scheme or netloc. This can be achieved by using `urlparse` and checking that both the `scheme` and `netloc` are empty after sanitizing the input. The fix should be applied in the `change_language` function in `app/views/language.py`, specifically in the logic that processes and validates `current_url` before redirecting. No new methods are needed, but the logic for validating `current_url` should be updated to follow the recommended pattern.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * リダイレクト時のURL検証を強化し、不正なリファラーURLや外部サイトへのリダイレクトを防止しました。  
  * バックスラッシュを含むリファラーURLが正しく処理されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->