### PR TITLE
Supabase処理失敗に対応

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -268,6 +268,11 @@ def not_found(error):
     return common.not_found_page_view()
 
 
+@app.errorhandler(500)
+def internal_server_error(error):
+    return common.internal_server_error_view()
+
+
 def main():
     """WSGIサーバー用のエントリーポイント
 

--- a/app/models/supabase_client.py
+++ b/app/models/supabase_client.py
@@ -349,7 +349,8 @@ class SupabaseService:
         # 用意したqueryを実行し、データを取得
         try:
             response = query.execute()
-        except Exception:
+        except Exception as e:
+            print("SupabaseClient get_data error:", e)
             return None
 
         # 取得したデータをキャッシュに保存
@@ -393,7 +394,8 @@ class SupabaseService:
         )
         try:
             response = query.execute()
-        except Exception:
+        except Exception as e:
+            print("SupabaseClient get_tavily_data error:", e)
             return None
 
         if len(response.data) == 0:

--- a/app/models/supabase_client.py
+++ b/app/models/supabase_client.py
@@ -347,7 +347,10 @@ class SupabaseService:
                 query = query.order(order_by)
 
         # 用意したqueryを実行し、データを取得
-        response = query.execute()
+        try:
+            response = query.execute()
+        except Exception:
+            return None
 
         # 取得したデータをキャッシュに保存
         flask_cache.set(cache_key, response.data, timeout=15 * MINUTE)
@@ -388,7 +391,10 @@ class SupabaseService:
         query = (
             self.admin_client.table("Tavily").select(column).eq("cache_key", cache_key)
         )
-        response = query.execute()
+        try:
+            response = query.execute()
+        except Exception:
+            return None
 
         if len(response.data) == 0:
             return []

--- a/app/templates/common/500.html
+++ b/app/templates/common/500.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block title %}GBBINFO-JPN{% endblock %}
+{% block twitter_title %}GBBINFO-JPN{% endblock %}
+{% block og_title %}GBBINFO-JPN{% endblock %}
+{% block og_url %}https://gbbinfo-jpn.onrender.com/{% endblock %}
+{% block canonical %}https://gbbinfo-jpn.onrender.com/{% endblock %}
+
+{% block head %}
+<meta name="robots" content="noindex, nofollow">
+{% endblock %}
+{% block content %}
+<h1>500 internal server error</h1>
+<p>{{_("まもなくトップページへリダイレクトされます")}}<br>{{_("リダイレクトされない場合、以下のボタンをご利用ください")}}</p>
+
+<div class="button-container">
+    <a href="/"><button type="button">{{_("トップページ")}}</button></a>
+</div>
+
+<script>
+    setTimeout(function() {
+        location.replace('/');
+    }, 2000);
+</script>
+
+{% endblock %}

--- a/app/tests/tests.py
+++ b/app/tests/tests.py
@@ -1722,6 +1722,277 @@ class SupabaseServiceTestCase(unittest.TestCase):
                     self.assertEqual(str(context.exception), expected_message)
 
 
+class SupabaseErrorHandlingTestCase(unittest.TestCase):
+    """Supabaseからの応答がない場合のエラーハンドリングのテストケース"""
+
+    def setUp(self):
+        """テストの前準備"""
+        app.config["TESTING"] = True
+        app.config["WTF_CSRF_ENABLED"] = False
+        self.client = app.test_client()
+        self.app_context = app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        """テスト後のクリーンアップ"""
+        self.app_context.pop()
+
+    @patch("app.views.result.supabase_service")
+    @patch("app.context_processors.get_translated_urls")
+    @patch("app.context_processors.is_gbb_ended")
+    @patch("app.context_processors.get_available_years")
+    def test_result_view_supabase_no_response(
+        self,
+        mock_get_available_years,
+        mock_is_gbb_ended,
+        mock_get_translated_urls,
+        mock_supabase,
+    ):
+        """result_viewでSupabaseからの応答がない場合に500エラーが返されることをテスト"""
+        mock_get_available_years.return_value = [2025]
+        mock_is_gbb_ended.return_value = False
+        mock_get_translated_urls.return_value = set()
+
+        # Supabaseからの応答なし（空のDataFrame）
+        mock_supabase.get_data.return_value = None
+
+        with self.client.session_transaction() as sess:
+            sess["language"] = "ja"
+
+        resp = self.client.get("/2025/result?category=Loopstation")
+        self.assertEqual(resp.status_code, 500)
+
+    @patch("app.views.world_map.os.path.exists")
+    @patch("app.views.world_map.supabase_service")
+    @patch("app.context_processors.get_translated_urls")
+    @patch("app.context_processors.is_gbb_ended")
+    @patch("app.context_processors.get_available_years")
+    def test_world_map_view_supabase_no_response(
+        self,
+        mock_get_available_years,
+        mock_is_gbb_ended,
+        mock_get_translated_urls,
+        mock_supabase,
+        mock_os_path_exists,
+    ):
+        """world_map_viewでSupabaseからの応答がない場合に500エラーが返されることをテスト"""
+        mock_get_available_years.return_value = [2025]
+        mock_is_gbb_ended.return_value = False
+        mock_get_translated_urls.return_value = set()
+
+        # マップファイルが存在しないようにする
+        mock_os_path_exists.return_value = False
+
+        # Supabaseからの応答なし
+        mock_supabase.get_data.return_value = None
+
+        with self.client.session_transaction() as sess:
+            sess["language"] = "ja"
+
+        resp = self.client.get("/2025/world_map")
+        self.assertEqual(resp.status_code, 500)
+
+    @patch("app.views.participants.supabase_service")
+    @patch("app.context_processors.get_translated_urls")
+    @patch("app.context_processors.is_gbb_ended")
+    @patch("app.context_processors.get_available_years")
+    def test_participants_view_supabase_no_response(
+        self,
+        mock_get_available_years,
+        mock_is_gbb_ended,
+        mock_get_translated_urls,
+        mock_supabase,
+    ):
+        """participants_viewでSupabaseからの応答がない場合に500エラーが返されることをテスト"""
+        mock_get_available_years.return_value = [2025]
+        mock_is_gbb_ended.return_value = False
+        mock_get_translated_urls.return_value = set()
+
+        # Supabaseからの応答なし
+        mock_supabase.get_data.return_value = None
+
+        with self.client.session_transaction() as sess:
+            sess["language"] = "ja"
+
+        resp = self.client.get("/2025/participants")
+        self.assertEqual(resp.status_code, 500)
+
+    @patch("app.views.search_participants.supabase_service")
+    @patch("app.context_processors.get_translated_urls")
+    @patch("app.context_processors.is_gbb_ended")
+    @patch("app.context_processors.get_available_years")
+    def test_search_participants_supabase_no_response(
+        self,
+        mock_get_available_years,
+        mock_is_gbb_ended,
+        mock_get_translated_urls,
+        mock_supabase,
+    ):
+        """search_participantsでSupabaseからの応答がない場合に500エラーが返されることをテスト"""
+        mock_get_available_years.return_value = [2025]
+        mock_is_gbb_ended.return_value = False
+        mock_get_translated_urls.return_value = set()
+
+        # Supabaseからの応答なし
+        mock_supabase.get_data.return_value = None
+
+        with self.client.session_transaction() as sess:
+            sess["language"] = "ja"
+
+        request_data = json.dumps({"keyword": "test"})
+        resp = self.client.post(
+            "/2025/search_participants",
+            data=request_data,
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 500)
+
+    @patch("app.views.result.supabase_service")
+    @patch("app.context_processors.get_translated_urls")
+    @patch("app.context_processors.is_gbb_ended")
+    @patch("app.context_processors.get_available_years")
+    def test_result_view_empty_dataframe(
+        self,
+        mock_get_available_years,
+        mock_is_gbb_ended,
+        mock_get_translated_urls,
+        mock_supabase,
+    ):
+        """result_viewで空のDataFrameが返される場合に500エラーが返されることをテスト"""
+        import pandas as pd
+
+        mock_get_available_years.return_value = [2025]
+        mock_is_gbb_ended.return_value = False
+        mock_get_translated_urls.return_value = set()
+
+        # 空のDataFrameを返す
+        mock_supabase.get_data.return_value = pd.DataFrame()
+
+        with self.client.session_transaction() as sess:
+            sess["language"] = "ja"
+
+        resp = self.client.get("/2025/result?category=Loopstation")
+        self.assertEqual(resp.status_code, 500)
+
+    @patch("app.views.participants.supabase_service")
+    @patch("app.context_processors.get_translated_urls")
+    @patch("app.context_processors.is_gbb_ended")
+    @patch("app.context_processors.get_available_years")
+    def test_participants_view_empty_dataframe(
+        self,
+        mock_get_available_years,
+        mock_is_gbb_ended,
+        mock_get_translated_urls,
+        mock_supabase,
+    ):
+        """participants_viewで空のDataFrameが返される場合に500エラーが返されることをテスト"""
+        import pandas as pd
+
+        mock_get_available_years.return_value = [2025]
+        mock_is_gbb_ended.return_value = False
+        mock_get_translated_urls.return_value = set()
+
+        # 空のDataFrameを返す
+        mock_supabase.get_data.return_value = pd.DataFrame()
+
+        with self.client.session_transaction() as sess:
+            sess["language"] = "ja"
+
+        resp = self.client.get("/2025/participants")
+        self.assertEqual(resp.status_code, 500)
+
+    @patch("app.views.search_participants.supabase_service")
+    @patch("app.context_processors.get_translated_urls")
+    @patch("app.context_processors.is_gbb_ended")
+    @patch("app.context_processors.get_available_years")
+    def test_search_participants_empty_response(
+        self,
+        mock_get_available_years,
+        mock_is_gbb_ended,
+        mock_get_translated_urls,
+        mock_supabase,
+    ):
+        """search_participantsで空のレスポンスが返される場合に500エラーが返されることをテスト"""
+        mock_get_available_years.return_value = [2025]
+        mock_is_gbb_ended.return_value = False
+        mock_get_translated_urls.return_value = set()
+
+        # 空のリストを返す
+        mock_supabase.get_data.return_value = []
+
+        with self.client.session_transaction() as sess:
+            sess["language"] = "ja"
+
+        request_data = json.dumps({"keyword": "test"})
+        resp = self.client.post(
+            "/2025/search_participants",
+            data=request_data,
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 500)
+
+    @patch("app.views.rule.supabase_service")
+    @patch("app.context_processors.get_translated_urls")
+    @patch("app.context_processors.is_gbb_ended")
+    @patch("app.context_processors.get_available_years")
+    def test_rule_view_continues_with_empty_data(
+        self,
+        mock_get_available_years,
+        mock_is_gbb_ended,
+        mock_get_translated_urls,
+        mock_supabase,
+    ):
+        """rule_viewでSupabaseからの応答がない場合に空のデータでページを表示することをテスト
+
+        Note: rule.pyでは44-51行目でSupabaseからのデータが取得できない場合、
+        空のコンテキスト（gbb_seed, other_seed, cancelled すべて空配列）でページを表示する
+        """
+        mock_get_available_years.return_value = [2025]
+        mock_is_gbb_ended.return_value = False
+        mock_get_translated_urls.return_value = set()
+
+        # 空のリストを返す（Supabaseからデータが取得できない状況をシミュレート）
+        mock_supabase.get_data.return_value = []
+
+        with self.client.session_transaction() as sess:
+            sess["language"] = "ja"
+
+        resp = self.client.get("/2025/rule")
+        # rule.pyでは空のデータでもページを表示するため200が返される
+        self.assertEqual(resp.status_code, 200)
+
+        # レスポンスのHTMLに空のデータが適用されていることを確認
+        html = resp.get_data(as_text=True)
+        # 空のシード権獲得者リストでもページが正常に表示されることを確認
+        self.assertIn("rule", html.lower())  # ルールページが表示されていることを確認
+
+    @patch("app.views.rule.supabase_service")
+    @patch("app.context_processors.get_translated_urls")
+    @patch("app.context_processors.is_gbb_ended")
+    @patch("app.context_processors.get_available_years")
+    def test_rule_view_supabase_none_response(
+        self,
+        mock_get_available_years,
+        mock_is_gbb_ended,
+        mock_get_translated_urls,
+        mock_supabase,
+    ):
+        """rule_viewでSupabaseからNoneが返される場合のテスト"""
+        mock_get_available_years.return_value = [2025]
+        mock_is_gbb_ended.return_value = False
+        mock_get_translated_urls.return_value = set()
+
+        # Noneを返す（Supabaseからの応答がない状況をシミュレート）
+        mock_supabase.get_data.return_value = None
+
+        with self.client.session_transaction() as sess:
+            sess["language"] = "ja"
+
+        resp = self.client.get("/2025/rule")
+        # rule.pyでは応答がなくても空のデータでページを表示するため200が返される
+        self.assertEqual(resp.status_code, 200)
+
+
 class BeatboxerTavilySearchTestCase(unittest.TestCase):
     """beatboxer_tavily_search.pyの関数テストケース"""
 

--- a/app/views/beatboxer_tavily_search.py
+++ b/app/views/beatboxer_tavily_search.py
@@ -33,17 +33,17 @@ def get_primary_domain(url: str) -> str:
 # MARK: 出場者名取得
 def get_beatboxer_name(beatboxer_id: int, mode: str = "single"):
     """
-    出場者IDから出場者名を取得し、大文字で返します。
+    出場者IDから出場者名を取得し、大文字で返す関数。
 
     Args:
-        beatboxer_id (int): 取得対象の出場者ID。
-        mode (str, optional): 取得モード。"single"の場合は個人出場者、"team_member"の場合はチームメンバーとして取得します。デフォルトは"single"。
+        beatboxer_id (int): 取得したい出場者のID。
+        mode (str, optional): 取得モード。"single"の場合は個人出場者、"team_member"の場合はチームメンバーとして取得する。デフォルトは"single"。
 
     Returns:
-        str: 出場者名（大文字）。
+        str: 出場者名（大文字）。該当する出場者が存在しない場合は空文字列を返す。
 
-    Raises:
-        IndexError: 指定したIDに該当する出場者が存在しない場合。
+    Note:
+        supabaseからデータ取得に失敗した場合も空文字列を返す。
     """
     # 出場者名を取得
     participant_data = supabase_service.get_data(

--- a/app/views/beatboxer_tavily_search.py
+++ b/app/views/beatboxer_tavily_search.py
@@ -61,6 +61,11 @@ def get_beatboxer_name(beatboxer_id: int, mode: str = "single"):
                 "id": beatboxer_id,
             },
         )
+
+    # supabaseから取得失敗した場合、空文字列を返す
+    if participant_data is None:
+        return ""
+
     beatboxer_name = participant_data[0]["name"].upper()
     return beatboxer_name
 
@@ -120,6 +125,10 @@ def beatboxer_tavily_search(
     # beatboxer_nameが指定されていない場合は、beatboxer_idから取得
     if beatboxer_name is None:
         beatboxer_name = get_beatboxer_name(beatboxer_id, mode)
+
+        # supabaseから取得失敗した場合、空リストを返す
+        if beatboxer_name == "":
+            return ([], [], "")
 
     # キャッシュキーを作成（スペースやその他の特殊文字を安全な文字に置換）
     cache_key = (
@@ -284,6 +293,11 @@ def translate_tavily_answer(beatboxer_id: int, mode: str, language: str):
     """
     # まずキャッシュを取得
     beatboxer_name = get_beatboxer_name(beatboxer_id, mode)
+
+    # supabaseから取得失敗した場合、空文字列を返す
+    if beatboxer_name == "":
+        return ""
+
     cache_key = (
         f"tavily_search_{re.sub(r'[^a-zA-Z0-9_-]', '_', beatboxer_name.strip())}"
     )

--- a/app/views/common.py
+++ b/app/views/common.py
@@ -102,3 +102,11 @@ def not_found_page_view():
         "is_translated": True,
     }
     return render_template("common/404.html", context=context), 404
+
+
+# MARK: 500
+def internal_server_error_view():
+    """
+    500ページを表示する。
+    """
+    return render_template("common/500.html"), 500

--- a/app/views/participant_detail.py
+++ b/app/views/participant_detail.py
@@ -54,7 +54,7 @@ def participant_detail_view():
             },
         )
         # データがない場合、出場者ページへリダイレクト
-        if len(beatboxer_data) == 0:
+        if not beatboxer_data:
             year = datetime.now().year
             return redirect(f"/{year}/participants")
 
@@ -101,7 +101,7 @@ def participant_detail_view():
         )
 
         # データがない場合、出場者ページへリダイレクト
-        if len(beatboxer_data) == 0:
+        if not beatboxer_data:
             year = datetime.now().year
             return redirect(f"/{year}/participants")
 

--- a/app/views/participants.py
+++ b/app/views/participants.py
@@ -41,7 +41,7 @@ def participants_view(year: int):
         pandas=True,
     )
     # supabaseから取得失敗した場合、500エラーを返す
-    if year_data is None:
+    if year_data is None or year_data.empty:
         abort(500)
 
     # 以降、supabaseと接続ができるとみなす

--- a/app/views/participants.py
+++ b/app/views/participants.py
@@ -1,4 +1,4 @@
-from flask import redirect, render_template, request, session
+from flask import abort, redirect, render_template, request, session
 
 from app.models.supabase_client import supabase_service
 from app.util.filter_eq import Operator
@@ -40,6 +40,12 @@ def participants_view(year: int):
         },
         pandas=True,
     )
+    # supabaseから取得失敗した場合、500エラーを返す
+    if year_data is None:
+        abort(500)
+
+    # 以降、supabaseと接続ができるとみなす
+
     all_categories_for_year_id = year_data["categories"].tolist()[0]
 
     # idから名前を取得

--- a/app/views/participants.py
+++ b/app/views/participants.py
@@ -57,6 +57,18 @@ def participants_view(year: int):
         },
         pandas=True,
     )
+
+    # カテゴリ名なし = 未定の場合 (公式発表前)
+    if category_data.empty:
+        context = {
+            "participants": [],
+            "all_category": [],
+            "category": category,
+            "ticket_class": ticket_class,
+            "cancel": cancel,
+        }
+        return render_template("common/participants.html", **context)
+
     all_category_names = category_data["name"].tolist()
 
     # 引数の正当性チェック

--- a/app/views/result.py
+++ b/app/views/result.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from flask import redirect, render_template, request
+from flask import abort, redirect, render_template, request
 
 from app.models.supabase_client import supabase_service
 from app.util.filter_eq import Operator
@@ -38,6 +38,12 @@ def result_view(year: int):
         },
         pandas=True,
     )
+    # supabaseから取得失敗した場合、500エラーを返す
+    if not year_data:
+        abort(500)
+
+    # 以降、supabaseと接続ができるとみなす
+
     all_categories_for_year_id = year_data["categories"].tolist()[0]
 
     # idから名前を取得

--- a/app/views/result.py
+++ b/app/views/result.py
@@ -39,7 +39,7 @@ def result_view(year: int):
         pandas=True,
     )
     # supabaseから取得失敗した場合、500エラーを返す
-    if not year_data:
+    if year_data is None or year_data.empty:
         abort(500)
 
     # 以降、supabaseと接続ができるとみなす

--- a/app/views/rule.py
+++ b/app/views/rule.py
@@ -41,7 +41,7 @@ def rules_view(year: int):
         },
     )
 
-    # supabaseから取得失敗した場合、500エラーを返す
+    # supabaseから取得失敗した場合、空のデータでページを表示する
     if not participants_data:
         context = {
             "gbb_seed": [],

--- a/app/views/rule.py
+++ b/app/views/rule.py
@@ -41,6 +41,15 @@ def rules_view(year: int):
         },
     )
 
+    # supabaseから取得失敗した場合、500エラーを返す
+    if not participants_data:
+        context = {
+            "gbb_seed": [],
+            "other_seed": [],
+            "cancelled": [],
+        }
+        return render_template(f"{year}/rule.html", **context)
+
     gbb_seed = []
     other_seed = []
     cancelled = []

--- a/app/views/search_participants.py
+++ b/app/views/search_participants.py
@@ -1,4 +1,4 @@
-from flask import jsonify, request
+from flask import abort, jsonify, request
 from rapidfuzz import process
 
 from app.models.supabase_client import supabase_service
@@ -36,7 +36,7 @@ def post_search_participants(year: int):
     )
 
     # 検索結果が無い場合、キーワードの最初1文字のみで検索
-    if len(participants_data) == 0:
+    if not participants_data:
         participants_data = supabase_service.get_data(
             table="Participant",
             columns=["id", "name", "category", "ticket_class", "is_cancelled"],
@@ -45,8 +45,17 @@ def post_search_participants(year: int):
                 "Category": ["id", "name"],
                 "ParticipantMember": ["id", "name"],
             },
-            filters={"year": year, f"name__{Operator.MATCH_IGNORE_CASE}": f"%{keyword[0]}%"},
+            filters={
+                "year": year,
+                f"name__{Operator.MATCH_IGNORE_CASE}": f"%{keyword[0]}%",
+            },
         )
+
+    # supabaseから取得失敗した場合、500エラーを返す
+    if not participants_data:
+        abort(500)
+
+    # 以降、supabaseと接続ができるとみなす
 
     for participant in participants_data:
         participant["name"] = participant["name"].upper()

--- a/app/views/search_participants.py
+++ b/app/views/search_participants.py
@@ -52,7 +52,7 @@ def post_search_participants(year: int):
         )
 
     # supabaseから取得失敗した場合、500エラーを返す
-    if not participants_data:
+    if participants_data is None or len(participants_data) == 0:
         abort(500)
 
     # 以降、supabaseと接続ができるとみなす

--- a/app/views/world_map.py
+++ b/app/views/world_map.py
@@ -2,7 +2,7 @@ import os
 from collections import defaultdict
 
 import folium
-from flask import render_template, session
+from flask import abort, render_template, session
 
 from app.models.supabase_client import supabase_service
 
@@ -47,6 +47,11 @@ def world_map_view(year: int):
         },
         filters={"year": year, "is_cancelled": False},
     )
+    # supabaseから取得失敗した場合、500エラーを返す
+    if not participants_data:
+        return abort(500)
+
+    # 以降、supabaseと接続ができるとみなす
 
     participants_per_country = defaultdict(list)
 

--- a/app/views/world_map.py
+++ b/app/views/world_map.py
@@ -48,8 +48,8 @@ def world_map_view(year: int):
         filters={"year": year, "is_cancelled": False},
     )
     # supabaseから取得失敗した場合、500エラーを返す
-    if not participants_data:
-        return abort(500)
+    if participants_data is None:
+        abort(500)
 
     # 以降、supabaseと接続ができるとみなす
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 500エラーページを追加（自動リダイレクト・noindex対応）とアプリ全体での500ハンドリングを導入。
- バグ修正
  - Supabase応答がない/空のケースで明示的に500応答または空表示する保護を追加。検索のフォールバック取得、無効名時の早期リターンで例外を回避。
- リファクタ
  - 空データ判定をより簡潔な書き方に修正。
- テスト
  - データ欠如や空データ時の各ルート挙動（500/200）を網羅するテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->