### PR TITLE
更新: Crewの審査員を「CHRIS CELIZ」「EPOCK」「EON」に変更

### DIFF
--- a/app/templates/2026/rule.html
+++ b/app/templates/2026/rule.html
@@ -646,7 +646,7 @@
     </tr>
     <tr>
       <td>Crew</td>
-      <td>{{_("発表次第更新")}}</td>
+      <td>CHRIS CELIZ<br>EPOCK<br>EON</td>
     </tr>
     <tr>
       <td>SHOWCASE<br>(producer)</td>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **コンテンツ更新**
  * 2026年ルール内のワイルドカード部門審査員一覧を更新しました。審査員名（CHRIS CELIZ、EPOCK、EON）を追加いたしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->